### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/obsidian_html/utils.py
+++ b/obsidian_html/utils.py
@@ -30,7 +30,7 @@ def find_md_files(root, no_extension, is_extra_folder=False):
         if not md_file.endswith(".md"):
             continue
 
-        with open(os.path.join(root, md_file)) as f:
+        with open(os.path.join(root, md_file), encoding="utf8") as f:
             content = f.read()
 
         if no_extension:


### PR DESCRIPTION
I got an error 'UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 830' when running this.
By using utf8 instead of "none" (default: cp1252) you can avoid this issue.

Encoding could perhaps be a CLI option.