### PR TITLE
Fix UnicodeEncodeError when writing emoji

### DIFF
--- a/obsidian_html/Vault.py
+++ b/obsidian_html/Vault.py
@@ -54,5 +54,5 @@ class Vault:
                     title=note["title"], content=note["content"])
             else:
                 html = note["content"]
-            with open(os.path.join(out_dir, note["filename"]), "w") as f:
+            with open(os.path.join(out_dir, note["filename"]), "w", encoding="utf8") as f:
                 f.write(html)


### PR DESCRIPTION
If a source md file has emoji, the conversion will fail.
This fixes that problem.

Related to #3 and https://github.com/kmaasrud/obsidian-html/issues/3#issuecomment-705487846