### PR TITLE
Open template as utf8

### DIFF
--- a/obsidian_html/Vault.py
+++ b/obsidian_html/Vault.py
@@ -12,7 +12,7 @@ class Vault:
 
         self.html_template = html_template
         if html_template:
-            with open(html_template) as f:
+            with open(html_template, "r", encoding="utf8") as f:
                 self.html_template = f.read()
 
     def _add_backlinks(self):


### PR DESCRIPTION
Seems like a good precaution, as issues arose everywhere else where default
encoding was used.

Related to #2 and #5 .