### PR TITLE
Fix linking for Chrome/Windows

### DIFF
--- a/obsidian_html/Vault.py
+++ b/obsidian_html/Vault.py
@@ -21,7 +21,7 @@ class Vault:
             if backlinks:
                 note["content"] += "\n<div class=\"backlinks\" markdown=\"1\">\n## Backlinks\n\n"
                 for backlink in backlinks:
-                    note["content"] += f"- {md_link(backlink['text'], backlink['link'])}\n"
+                    note["content"] += f"- {md_link(backlink['text'], backlink['link']+'.html')}\n"
                 note["content"] += "</div>"
 
     def convert_to_html(self):

--- a/obsidian_html/Vault.py
+++ b/obsidian_html/Vault.py
@@ -28,7 +28,7 @@ class Vault:
         notes_html = []
         for note in self.notes:
             filename_html = slug_case(note["filename"]) + ".html"
-            content_html = htmlify(note["content"])
+            content_html = htmlify(note["content"], self.notes)
 
             notes_html.append(
                 {"filename": filename_html, "content": content_html, "title": note["filename"]})

--- a/obsidian_html/format.py
+++ b/obsidian_html/format.py
@@ -23,7 +23,7 @@ def format_internal_header_links(document):
 
     for match in matches:
         text = match.group(2)
-        link = slug_case(match.group(1)) + "#" + slug_case(match.group(2))
+        link = slug_case(match.group(1)) + ".html#" + slug_case(match.group(2))
         document = document.replace(match.group(), md_link(text, link))
 
     return document

--- a/obsidian_html/format.py
+++ b/obsidian_html/format.py
@@ -44,7 +44,7 @@ def obsidian_to_commonmark_links(document, matches, no_groups=2):
     for match in matches:
         text = match.group(no_groups)
         link = slug_case(match.group(1))
-        document = document.replace(match.group(), md_link(text, link))
+        document = document.replace(match.group(), md_link(text, link+".html"))
 
     return document
 


### PR DESCRIPTION
Update links so that they include ".html" file extensions (required by Chrome on Windows, at least for me)
Don't generate links if the underlying file isn't present. Worth considering whether you would want to visually indicate the link in some other way, but just having a broken link is definitely a poor experience.