### PR TITLE
add trailing .html to md_link

### DIFF
--- a/obsidian_html/utils.py
+++ b/obsidian_html/utils.py
@@ -9,7 +9,7 @@ def slug_case(text):
 
 
 def md_link(text, link):
-    return "[" + text + "](" + link + ")"
+    return "[" + text + "](" + link + ".html)"
 
 
 def extract_links_from_file(document):


### PR DESCRIPTION
Current code probably only works when you've got a webserver mapping no-extension paths to '.html'

This makes it a little more robust (and allows local browsing).