### PR TITLE
Severed backlinks from content and added filter for tags arg

### DIFF
--- a/obsidian_html/Note.py
+++ b/obsidian_html/Note.py
@@ -1,6 +1,6 @@
 import os
 import regex as re
-from obsidian_html.utils import slug_case, md_link
+from obsidian_html.utils import slug_case, md_link, render_markdown
 from obsidian_html.format import format_tags, format_blockrefs
 from obsidian_html.Link import Link
 
@@ -16,6 +16,8 @@ class Note:
 
         with open(path, encoding="utf8") as f:
             self.content = f.read()
+
+        self.backlinks = ""
 
         self.links = self.links_in_file()
 
@@ -53,7 +55,6 @@ class Note:
             self.content = self.content.replace(f"[[{link.obsidian_link}]]", link.md_link())
             
         self.content =  format_blockrefs(format_tags(self.content))
-
     
     def html(self, pandoc=False):
         """Returns the note formatted as HTML. Will use markdown2 as default, with the option of pandoc (WIP)"""
@@ -65,34 +66,7 @@ class Note:
             args = []
             html = pypandoc.convert_text(document, 'html', format='md', filters=filters, extra_args=args)
         else:
-            import markdown2
-            # Escaped curly braces lose their escapes when formatted. I'm suspecting
-            # this is from markdown2, as I haven't found anyplace which could
-            # do this among my own formatter functions. Therefore I double escape them.
-            document = document.replace(r"\{", r"\\{").replace(r"\}", r"\\}")
-
-            markdown2_extras = [
-                # Parser should work withouth strict linebreaks.
-                "break-on-newline",
-                # Support of ```-codeblocks and syntax highlighting.
-                "fenced-code-blocks",
-                # Make slug IDs for each header. Needed for internal header links.
-                "header-ids",
-                # Support for strikethrough formatting.
-                "strike",
-                # GFM tables.
-                "tables",
-                # Support for lists that start without a newline directly above.
-                "cuddled-lists",
-                # Support Markdown inside html tags
-                "markdown-in-html",
-                # Disable formatting via the _ character. Necessary for code and TeX
-                "code-friendly",
-                # Support for Obsidian's footnote syntax
-                "footnotes"
-            ]
-
-            html = markdown2.markdown(document, extras=markdown2_extras)
+            html = render_markdown(document)
 
         # Wrapping converted markdown in a div for styling
         html = f"<div id=\"content\">{html}</div>"

--- a/obsidian_html/Vault.py
+++ b/obsidian_html/Vault.py
@@ -1,5 +1,5 @@
 import os
-from obsidian_html.utils import slug_case, md_link
+from obsidian_html.utils import slug_case, md_link, render_markdown
 from obsidian_html.Note import Note
 
 
@@ -21,11 +21,12 @@ class Vault:
             others = [other for other in self.notes if other != note]
             backlinks = self.notes[i].find_backlinks(others)
             if backlinks:
-                self.notes[i].content += "\n<div class=\"backlinks\" markdown=\"1\">\n## Backlinks\n\n"
+                self.notes[i].backlinks += "\n<div class=\"backlinks\" markdown=\"1\">\n"
                 for backlink in backlinks:
-                    self.notes[i].content += f"- {backlink.md_link()}\n"
-                self.notes[i].content += "</div>"
+                    self.notes[i].backlinks += f"- {backlink.md_link()}\n"
+                self.notes[i].backlinks += "</div>"
 
+                self.notes[i].backlinks = render_markdown(self.notes[i].backlinks)
 
     def export_html(self, out_dir):
         # Default location of exported HTML is "html"
@@ -40,7 +41,7 @@ class Vault:
 
         for note in self.notes:
             if self.html_template:
-                html = self.html_template.format(title=note.title, content=note.html())
+                html = self.html_template.format(title=note.title, content=note.html(), backlinks=note.backlinks)
             else:
                 html = note.html()
             with open(os.path.join(out_dir, note.filename_html), "w", encoding="utf8") as f:

--- a/obsidian_html/__init__.py
+++ b/obsidian_html/__init__.py
@@ -27,7 +27,12 @@ def main():
                         default=[],
                         help="Extra sub-directories in vault that you want included")
 
+    parser.add_argument("-f", "--filter",
+                        nargs="+",
+                        default=[],
+                        help="Filter notes by tags")
+
     args = parser.parse_args()
 
-    vault = Vault(args.Vault, extra_folders=args.dirs, html_template=args.template)
+    vault = Vault(args.Vault, extra_folders=args.dirs, html_template=args.template, filter=args.filter)
     vault.export_html(args.output_dir)

--- a/obsidian_html/__main__.py
+++ b/obsidian_html/__main__.py
@@ -25,7 +25,12 @@ parser.add_argument("-d", "--dirs",
                     default=[],
                     help="Extra sub-directories in vault that you want included")
 
+parser.add_argument("-f", "--filter",
+                    nargs="+",
+                    default=[],
+                    help="Filter notes by tags")
+
 args = parser.parse_args()
 
-vault = Vault(args.Vault, extra_folders=args.dirs, html_template=args.template)
+vault = Vault(args.Vault, extra_folders=args.dirs, html_template=args.template, filter=args.filter)
 vault.export_html(args.output_dir)

--- a/obsidian_html/format.py
+++ b/obsidian_html/format.py
@@ -4,7 +4,7 @@ from obsidian_html.utils import slug_case, md_link
 
 def format_tags(document):
     """Obsidian style tags. Removes #-icon and adds a span tag."""
-    matches = re.finditer(r"\s#([\p{L}_]+)", document)
+    matches = re.finditer(r"\s#([\p{L}_-]+)", document)
 
     for match in matches:
         document = document.replace(

--- a/obsidian_html/utils.py
+++ b/obsidian_html/utils.py
@@ -1,5 +1,6 @@
 import regex as re
 import os
+import markdown2
 
 
 def slug_case(text):
@@ -34,3 +35,32 @@ def find_backlinks(target_note_name, all_notes):
     backlinks = sorted(backlinks, key=lambda x: x['text'])
 
     return backlinks
+
+def render_markdown(text):
+    # Escaped curly braces lose their escapes when formatted. I'm suspecting
+    # this is from markdown2, as I haven't found anyplace which could
+    # do this among my own formatter functions. Therefore I double escape them.
+    text = text.replace(r"\{", r"\\{").replace(r"\}", r"\\}")
+
+    markdown2_extras = [
+        # Parser should work withouth strict linebreaks.
+        "break-on-newline",
+        # Support of ```-codeblocks and syntax highlighting.
+        "fenced-code-blocks",
+        # Make slug IDs for each header. Needed for internal header links.
+        "header-ids",
+        # Support for strikethrough formatting.
+        "strike",
+        # GFM tables.
+        "tables",
+        # Support for lists that start without a newline directly above.
+        "cuddled-lists",
+        # Support Markdown inside html tags
+        "markdown-in-html",
+        # Disable formatting via the _ character. Necessary for code and TeX
+        "code-friendly",
+        # Support for Obsidian's footnote syntax
+        "footnotes"
+    ]
+
+    return markdown2.markdown(text, extras=markdown2_extras)


### PR DESCRIPTION
- Backlinks can now be added to a template with `{backlinks}`
- Filter works with `-f` or `--filter "evergreen" "journal"` and only exports notes with the requested tags present
- `-` in tags was not honored. regex now captures tags like `#research-log` as well